### PR TITLE
allow unverifiedTLS connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 `go-metronome` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+### v0.8
+- Add AllowUnverifiedTls to config struct to allow use with self-signed certs
 
 ### v0.7
 - Included undocumented `embed=` uri parameters found in the metronome source that give better picture of status

--- a/metronome/client_test.go
+++ b/metronome/client_test.go
@@ -45,6 +45,16 @@ var _ = Describe("Client", func() {
 			Expect(err).To(BeNil())
 		})
 
+		It("Defaults to unverifiedtls being false", func() {
+			test_config := Config{
+				URL:            server.URL(),
+				Debug:          false,
+				RequestTimeout: 5,
+			}
+
+			Expect(test_config.AllowUnverifiedTls).To(BeFalse())
+		})
+
 		It("Errors if it cannot hit metronome", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(

--- a/metronome/config.go
+++ b/metronome/config.go
@@ -8,11 +8,12 @@ type Config struct {
 	Debug bool
 	/* the timeout for requests */
 	RequestTimeout int
+	/* allow unverified tls (self-signed certs) defaults to false */
+	AllowUnverifiedTls bool
 
 	AuthToken string
-	User string
-	Pw string
-
+	User      string
+	Pw        string
 }
 
 // NewDefaultConfig returns a default configuration.


### PR DESCRIPTION
/cc @adobe-platform/go-metronome-reviewers 
Greetings and thanks for the PR.  We have a few rules so that everyone enjoys your Pull Request.

## Changelog
* Supports UnverifiedTLS via config struct

## Notes

No

If so:
 
Is it reflected in the metronome-cli?


## Tests
* Test checks if default for UnverifiedTls is false 

